### PR TITLE
Update card image styling in custom.css

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -97,9 +97,15 @@
 }
 
 .card.person .card-image img {
-  border-radius: 15px;
-  width: auto;
-  max-height: 96px;
+  border-radius: 20px;
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .card.person .card-image img {
+    margin-top: 30px;
+    width: 66%;
+  }
 }
 
 .card.person .card-content {


### PR DESCRIPTION
This pull request updates the card image styling in the custom.css file. The changes include increasing the border-radius to 20px and setting the width to 100% for the .card.person .card-image img class, showing member faces in a larger and rounded fashion on all devices.

Additionally, a media query has been added for small sized screens, which prevents such images from becoming exaggerately large on those screens.

These changes improve the appearance and responsiveness of the card images.

Since I had a few issues doing a local deployment I highly suggest trying out the modifications before rolling them out.